### PR TITLE
insert method

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,7 +3,8 @@
 ## v0.0.2 (unreleased)
 
 * Added a ``remove_index`` to remove unwanted index,
-* Added an "update" method,
+* Added an ``update`` method,
+* Added an ``insert`` method,
 * Dropped msgpack format: it was a bad idea,
 * The tox test grid is now complete,
 

--- a/meuhdb/core.py
+++ b/meuhdb/core.py
@@ -3,6 +3,7 @@
 MeuhDB, a database that says "meuh".
 """
 from __future__ import unicode_literals
+from uuid import uuid4
 import os
 from functools import wraps
 import json
@@ -124,6 +125,13 @@ class MeuhDb(object):
             self.delete_from_index(key)
         self.data[key] = value
         self.update_index(key, value)
+
+    @autocommit
+    def insert(self, value):
+        "Insert value in the keystore. Return the UUID key."
+        key = str(uuid4())
+        self.set(key, value)
+        return key
 
     @autocommit
     def delete(self, key):

--- a/meuhdb/tests.py
+++ b/meuhdb/tests.py
@@ -44,6 +44,10 @@ class DatabaseTest(InMemoryDatabase, TestCase):
         self.db.update('other', {'hello': 'world'})
         self.assertEquals(self.db.get('other'), {'hello': 'world'})
 
+    def test_insert(self):
+        key = self.db.insert({'hello': 'world'})
+        self.assertEquals(self.db.get(key), {'hello': 'world'})
+
 
 class DatabaseStoreTest(TestCase):
     def setUp(self):
@@ -145,6 +149,11 @@ class DatabaseStoreAutocommitTest(TestCase):
         index = db.indexes['name']
         self.assertEquals(index['Alice'], set(['1']))
         self.assertEquals(index['Bob'], set(['2']))
+
+    def test_autocommit_insert(self):
+        key = self.db.insert({'hello': 'world'})
+        db = MeuhDb(self.filename)  # reload
+        self.assertEquals(db.get(key), {'hello': 'world'})
 
 
 class DatabaseFilter(InMemoryDatabaseData, TestCase):


### PR DESCRIPTION
To insert a dictionary without providing an ID.
a UUID would be generated and returned by the insert method.
